### PR TITLE
Just run lint on test stage of CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ jobs:
       name: Test
       node_js:
         - 10.16.3
-      script: yarn test
+      script: yarn lint
 
     - stage: deploy
       if:

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "lint": "tslint --project tsconfig.json",
-    "test": "tslint --project tsconfig.json"
+    "lint": "tslint --project tsconfig.json"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
No tests, so we should just run `yarn lint` on CI.